### PR TITLE
Redirect http and www traffic to root https

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -17,6 +17,20 @@
 ServerSignature Off
 
 
+# -------------
+# | Redirects |
+# -------------
+
+RewriteEngine On
+# Push all non-https traffic to https:
+# See http://kb.siteground.com/how_to_redirect_my_website_to_be_opened_through_https/
+RewriteCond %{HTTPS} !=on
+RewriteRule .* https://getawkward.co.uk%{REQUEST_URI} [R,L]
+# Redirect any https traffic starting with 'www.' to the root
+# https://www.siteground.com/kb/how_to_redirect_www_urls_to_nonwww/
+RewriteCond %{HTTP_HOST} ^www.getawkward.co.uk [NC]
+RewriteRule ^(.*)$ https://getawkward.co.uk/$1 [L,R=301]
+
 
 # ----------------------------------------------------------------------
 # | ETags                                                              |


### PR DESCRIPTION
Two redirects copied from the Sitegrounds FAQs because I have not written an `htaccess` redirect in almost ten years :scream: 

* First, redirect all `http` traffic to `https` (strip the leading `www.` if it was included)
* Second, any `www.` traffic that arrives redirect that to the root.

This means that the canonical URL for the site should end up as https://getawkward.co.uk/